### PR TITLE
docs: add python gitlab CI

### DIFF
--- a/ci-setups/python-gitlab.md
+++ b/ci-setups/python-gitlab.md
@@ -1,0 +1,74 @@
+# Python CI Setup Guide for GitLab
+
+## Table of Contents
+1. **Introduction**
+2. **Prerequisites**
+3. **CI Configuration Overview**
+4. **Defining the Pipeline**
+5. **Configuring Variables**
+6. **Pipeline Stages**
+    - Lint
+    - Test
+7. **Workflow Rules**
+8. **Example `.gitlab-ci.yml`**
+9. **Conclusion**
+
+## Introduction
+This guide outlines the setup of a Continuous Integration (CI) pipeline for Python projects at Osmosys on GitLab. It focuses on ensuring automated testing and linting for Python applications.
+
+## Prerequisites
+- A Python project hosted on GitLab.
+- A basic understanding of Python development and GitLab CI/CD concepts.
+
+## CI Configuration Overview
+The CI pipeline is defined in a `.gitlab-ci.yml` file located at the root of your project. This file specifies the environment, stages, and jobs that make up your CI pipeline.
+
+## Defining the Pipeline
+Your pipeline should include stages for linting your code and running tests. These stages ensure code quality and functionality before merging changes.
+
+## Configuring Variables
+Use variables to configure the pipeline dynamically. Notably:
+- `DEFAULT_IMAGE` for the Docker image used throughout the pipeline.
+- `merge_request_branches` for specifying which branches should trigger the pipeline when targeted by merge requests.
+
+## Pipeline Stages
+### Lint
+The lint stage checks the code quality using tools like `flake8`.
+### Test
+The test stage runs automated tests on your code, typically using `pytest`.
+
+## Workflow Rules
+Configure the pipeline to only run on merge requests targeting specified branches, improving efficiency and relevance of the CI process.
+
+## Example `.gitlab-ci.yml`
+```yaml
+variables:
+  DEFAULT_IMAGE: "python:3.12"
+  merge_request_branches: "/^main|development$/"
+
+image: $DEFAULT_IMAGE
+
+stages:
+  - lint
+  - test
+
+before_script:
+  - pip install -r requirements.txt
+
+lint:
+  stage: lint
+  script:
+    - flake8 .
+
+test:
+  stage: test
+  script:
+    - pytest tests/
+
+workflow:
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event" && $CI_MERGE_REQUEST_TARGET_BRANCH_NAME =~ $merge_request_branches'
+```
+
+## Conclusion
+Implementing a CI pipeline in GitLab for your Python projects facilitates automated testing and linting, ensuring high code quality and functionality. This setup guide helps you utilize GitLab CI/CD features effectively for Python application development.

--- a/ci-setups/python-gitlab.md
+++ b/ci-setups/python-gitlab.md
@@ -1,52 +1,124 @@
-# Python CI Setup Guide for GitLab
+# Continuous Integration (CI) Setup for Python Projects in GitLab
 
 ## Table of Contents
-1. **Introduction**
-2. **Prerequisites**
-3. **CI Configuration Overview**
-4. **Defining the Pipeline**
-5. **Configuring Variables**
-6. **Pipeline Stages**
-    - Lint
-    - Test
-7. **Workflow Rules**
-8. **Updated `.gitlab-ci.yml` Example**
-9. **Conclusion**
 
-## Introduction
-This guide provides a detailed walkthrough for setting up a Continuous Integration (CI) pipeline for Python projects at Osmosys using GitLab. It emphasizes automating testing and linting to maintain high-quality code standards.
+- [Continuous Integration (CI) Setup for Python Projects in GitLab](#continuous-integration-ci-setup-for-python-projects-in-gitlab)
+  - [Table of Contents](#table-of-contents)
+  - [1. Introduction](#1-introduction)
+    - [Purpose](#purpose)
+    - [Scope](#scope)
+  - [2. Prerequisites](#2-prerequisites)
+  - [3. Setting Up Continuous Integration (CI) for Python Project](#3-setting-up-continuous-integration-ci-for-python-project)
+    - [Creating a `.gitlab-ci.yml` File](#creating-a-gitlab-ciyml-file)
+    - [Defining the Pipeline](#defining-the-pipeline)
+      - [Lint](#lint)
+      - [Test](#test)
+    - [Defining Variables](#defining-variables)
+    - [Installing Dependencies Before Running Script](#installing-dependencies-before-running-script)
+    - [Writing Jobs for Linting and Testing](#writing-jobs-for-linting-and-testing)
+    - [Adding Workflow Rules](#adding-workflow-rules)
+    - [Complete `.gitlab-ci.yml` Configuration](#complete-gitlab-ciyml-configuration)
+  - [4. Conclusion](#4-conclusion)
+    - [Benefits of CI Setup](#benefits-of-ci-setup)
+    - [Future Enhancements](#future-enhancements)
 
-## Prerequisites
-- A Python project hosted on GitLab.
+## 1. Introduction
+
+### Purpose
+
+The purpose of this document is to provide a step-by-step guide for setting up a Continuous Integration (CI) pipeline for a Python project in GitLab. The CI pipeline will automate linting and testing processes to ensure code quality and reliability.
+
+### Scope
+
+This document covers the basic setup of a CI pipeline for a Python project in GitLab, focusing on linting and testing stages. More advanced topics, such as deployment and additional stages, are outside the scope of this guide.
+
+## 2. Prerequisites
+
+Before setting up the CI pipeline, ensure you have the following prerequisites:
+
+- A GitLab account with access to your target repository.
+- A Python project repository hosted on GitLab.
 - Basic knowledge of Python development and GitLab CI/CD principles.
+- The CI runner needs to be properly configured by your IT administrator to execute CI tasks. In case of GitLab, you need to set up and register GitLab Runners on the machines where your CI/CD jobs will run. These runners should be configured to work with your GitLab project.
 
-## CI Configuration Overview
+## 3. Setting Up Continuous Integration (CI) for Python Project
+
+### Creating a `.gitlab-ci.yml` File
+
 The foundation of the CI pipeline is the `.gitlab-ci.yml` file placed at the project's root. This configuration file outlines the environment settings, stages, and jobs that constitute your CI pipeline.
 
-## Defining the Pipeline
-The pipeline comprises stages dedicated to linting code and running automated tests, essential practices for upholding code quality and verifying functionality.
+### Defining the Pipeline
 
-## Configuring Variables
+The pipeline comprises stages dedicated to linting code and running automated tests, essential practices for upholding code quality and verifying functionality. In this guide, we will use two stages: `lint` and `test`.
+
+```yaml
+stages:
+  - lint
+  - test
+```
+
+#### Lint
+
+This stage employs tools like `flake8` to evaluate code quality.
+
+#### Test
+
+During this stage, the pipeline runs automated tests using `pytest`, setting the `PYTHONPATH` to ensure modules are correctly found.
+
+### Defining Variables
+
 Variables offer a way to dynamically adjust the pipeline's settings. Key variables include:
+
 - `DEFAULT_IMAGE`: Specifies the Docker image for the pipeline.
 - `merge_request_branches`: Determines which branches trigger the pipeline upon receiving merge requests.
 
-## Pipeline Stages
-### Lint
-This stage employs tools like `flake8` to evaluate code quality.
-### Test
-During this stage, the pipeline runs automated tests using `pytest`, setting the `PYTHONPATH` to ensure modules are correctly found.
+We will not be defining any variables in this guide, but can be done based on project needs.
 
-## Workflow Rules
+### Installing Dependencies Before Running Script
+
+We need to ensure that the different requirements have been installed before running the script.
+
+```yaml
+before_script:
+  - pip install -r requirements.txt
+```
+
+### Writing Jobs for Linting and Testing
+
+Create jobs within each stage to perform linting and testing tasks.
+
+```yaml
+lint:
+  stage: lint
+  script:
+    - flake8 .
+  tags:
+    - python-3.12 # Ensure you are using correct runner
+
+test:
+  stage: test
+  script:
+    - export PYTHONPATH=$PYTHONPATH:$(pwd) # Ensure Python can locate the project modules
+    - pytest tests/
+  tags:
+    - python-3.12 # Ensure you are using correct runner
+```
+
+### Adding Workflow Rules
+
 The pipeline's execution is fine-tuned to activate only for merge requests that target certain branches, streamlining the CI process to focus on critical updates.
 
-## Updated `.gitlab-ci.yml` Example
 ```yaml
-variables:
-  DEFAULT_IMAGE: "python:3.12"
+workflow:
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event" && $CI_MERGE_REQUEST_TARGET_BRANCH_NAME =~ /^main|development$/'
+```
 
-image: $DEFAULT_IMAGE
+### Complete `.gitlab-ci.yml` Configuration
 
+Here is the completed configuration for your `.gitlab-ci.yml` file:
+
+```yaml
 stages:
   - lint
   - test
@@ -74,5 +146,16 @@ workflow:
     - if: '$CI_PIPELINE_SOURCE == "merge_request_event" && $CI_MERGE_REQUEST_TARGET_BRANCH_NAME =~ /^main|development$/'
 ```
 
-## Conclusion
-By integrating a CI pipeline with your GitLab-hosted Python project, you leverage automated testing and linting capabilities, fostering a culture of quality and efficiency. The guidance provided here equips you to efficiently employ GitLab CI/CD features for Python app development, ensuring your code remains robust and reliable.
+## 4. Conclusion
+
+### Benefits of CI Setup
+
+Setting up a CI pipeline for your Python project offers several benefits:
+
+- Improved code quality through automated linting.
+- Early detection of errors and issues.
+- Streamlined collaboration through automated testing of merge requests.
+
+### Future Enhancements
+
+Consider enhancing your CI pipeline by adding additional stages such as unit testing, integration testing, and deployment to further improve the quality and reliability of your Python projects.

--- a/ci-setups/python-gitlab.md
+++ b/ci-setups/python-gitlab.md
@@ -10,41 +10,40 @@
     - Lint
     - Test
 7. **Workflow Rules**
-8. **Example `.gitlab-ci.yml`**
+8. **Updated `.gitlab-ci.yml` Example**
 9. **Conclusion**
 
 ## Introduction
-This guide outlines the setup of a Continuous Integration (CI) pipeline for Python projects at Osmosys on GitLab. It focuses on ensuring automated testing and linting for Python applications.
+This guide provides a detailed walkthrough for setting up a Continuous Integration (CI) pipeline for Python projects at Osmosys using GitLab. It emphasizes automating testing and linting to maintain high-quality code standards.
 
 ## Prerequisites
 - A Python project hosted on GitLab.
-- A basic understanding of Python development and GitLab CI/CD concepts.
+- Basic knowledge of Python development and GitLab CI/CD principles.
 
 ## CI Configuration Overview
-The CI pipeline is defined in a `.gitlab-ci.yml` file located at the root of your project. This file specifies the environment, stages, and jobs that make up your CI pipeline.
+The foundation of the CI pipeline is the `.gitlab-ci.yml` file placed at the project's root. This configuration file outlines the environment settings, stages, and jobs that constitute your CI pipeline.
 
 ## Defining the Pipeline
-Your pipeline should include stages for linting your code and running tests. These stages ensure code quality and functionality before merging changes.
+The pipeline comprises stages dedicated to linting code and running automated tests, essential practices for upholding code quality and verifying functionality.
 
 ## Configuring Variables
-Use variables to configure the pipeline dynamically. Notably:
-- `DEFAULT_IMAGE` for the Docker image used throughout the pipeline.
-- `merge_request_branches` for specifying which branches should trigger the pipeline when targeted by merge requests.
+Variables offer a way to dynamically adjust the pipeline's settings. Key variables include:
+- `DEFAULT_IMAGE`: Specifies the Docker image for the pipeline.
+- `merge_request_branches`: Determines which branches trigger the pipeline upon receiving merge requests.
 
 ## Pipeline Stages
 ### Lint
-The lint stage checks the code quality using tools like `flake8`.
+This stage employs tools like `flake8` to evaluate code quality.
 ### Test
-The test stage runs automated tests on your code, typically using `pytest`.
+During this stage, the pipeline runs automated tests using `pytest`, setting the `PYTHONPATH` to ensure modules are correctly found.
 
 ## Workflow Rules
-Configure the pipeline to only run on merge requests targeting specified branches, improving efficiency and relevance of the CI process.
+The pipeline's execution is fine-tuned to activate only for merge requests that target certain branches, streamlining the CI process to focus on critical updates.
 
-## Example `.gitlab-ci.yml`
+## Updated `.gitlab-ci.yml` Example
 ```yaml
 variables:
   DEFAULT_IMAGE: "python:3.12"
-  merge_request_branches: "/^main|development$/"
 
 image: $DEFAULT_IMAGE
 
@@ -59,16 +58,21 @@ lint:
   stage: lint
   script:
     - flake8 .
+  tags:
+    - python-3.12 # Ensure you are using correct runner
 
 test:
   stage: test
   script:
+    - export PYTHONPATH=$PYTHONPATH:$(pwd) # Ensure Python can locate the project modules
     - pytest tests/
+  tags:
+    - python-3.12 # Ensure you are using correct runner
 
 workflow:
   rules:
-    - if: '$CI_PIPELINE_SOURCE == "merge_request_event" && $CI_MERGE_REQUEST_TARGET_BRANCH_NAME =~ $merge_request_branches'
+    - if: '$CI_PIPELINE_SOURCE == "merge_request_event" && $CI_MERGE_REQUEST_TARGET_BRANCH_NAME =~ /^main|development$/'
 ```
 
 ## Conclusion
-Implementing a CI pipeline in GitLab for your Python projects facilitates automated testing and linting, ensuring high code quality and functionality. This setup guide helps you utilize GitLab CI/CD features effectively for Python application development.
+By integrating a CI pipeline with your GitLab-hosted Python project, you leverage automated testing and linting capabilities, fostering a culture of quality and efficiency. The guidance provided here equips you to efficiently employ GitLab CI/CD features for Python app development, ensuring your code remains robust and reliable.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Documentation**
	- Updated the guide for setting up a Continuous Integration (CI) pipeline for Python projects on GitLab to include detailed instructions for testing and linting automation.
	- Added information on defining the CI pipeline with linting and testing stages, setting up variables, installing dependencies, writing jobs, and workflow rules.
	- Included insights on the benefits of CI setup and suggestions for future enhancements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->