### PR TITLE
docs: Fix html attribute usage sequence in example html

### DIFF
--- a/coding-standards/html.md
+++ b/coding-standards/html.md
@@ -334,7 +334,7 @@ If the field takes a number, please use `type="number"`, if it takes email use `
 **Example**
 
 ```html
-<input type="text" class="form-control" id="txt-firstName">
+<input class="form-control" id="txt-firstName" type="text">
 <div class="row">
     <div></div>
     <div class="selected-row"></div>


### PR DESCRIPTION
As per coding standard for Attribute Order to be followed in the HTML [here](https://github.com/OsmosysSoftware/dev-standards/blob/main/coding-standards/html.md#attribute-order:~:text=Attributes-,Attribute%20Order,-HTML%20attributes%20should) is as follow

```
class
id, name
data-*
src, for, type, href, value
```

Following above standard, the example provided is changed

**What was earlier?**
```html
<input type="text" class="form-control" id="txt-firstName">
```

**What is proposed?**
```html
<input class="form-control" id="txt-firstName" type="text">
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the ordering of attributes in HTML input tags for enhanced readability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->