### PR TITLE
fix: disable class-methods-use-this

### DIFF
--- a/coding-standards/angular.md
+++ b/coding-standards/angular.md
@@ -337,6 +337,7 @@ To ensure proper setup, add the following configuration files to your project's 
                 "avoidEscape": true
               }
             ],
+            "class-methods-use-this": "off",
             "radix": "error",
             "eqeqeq": [
               "error",


### PR DESCRIPTION
As per this discussion -> https://github.com/OsmosysSoftware/dev-standards/issues/61

we need to disable 'class-methods-use-this' in our angular coding standard, so disabled it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated Angular coding standards to modify ESLint rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->