### PR TITLE
docs: update ui guidelines link

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The Coding Standards section of this repository houses detailed guides, each tai
 
 We provide guides for a diverse array of languages and technologies, including but not limited to:
 
-- [UI Guidelines](./coding-standards/UI.csv)
+- [UI Guidelines](./coding-standards/UI.md)
 - [Angular](./coding-standards/angular.md)
 - [CSS](./coding-standards/css.md)
 - [Database](./coding-standards/database.md)


### PR DESCRIPTION
Fix the extension for UI guidelines
Now the link points to the md file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the "UI Guidelines" link in the Coding Standards section from a CSV file to an MD file for better readability and accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->