### PR TITLE
fix: update sample repo link

### DIFF
--- a/ci-setups/php-github.md
+++ b/ci-setups/php-github.md
@@ -300,7 +300,7 @@ Modify the job steps in the `php-lint.yml` file to match your specific linting a
 
 ## 8. Sample Repository
 
-[Repository Link](https://github.com/OsmosysSoftware/angular-eslint-workflow-guide)
+[Repository Link](https://github.com/OsmosysSoftware/php-lint-workflow-guide)
 
 Explore this for practical demonstration of CI setups.
 


### PR DESCRIPTION
Update Sample repo link to point to php document instead of angular

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated repository link in the PHP GitHub CI setup guide to point to the correct `php-lint-workflow-guide`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->